### PR TITLE
`jquery` and `animate.css`: `peerDependencies` ← `dependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "animation",
     "animate.css"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "jquery": ">1.1.0",
     "animate.css": "*"
   },


### PR DESCRIPTION
After this patch `jquery` and `animate.css` are removed from the `dependencies` section of `package.json` and they're granted `peerDependencies` status instead of it.

Rationale:
- All of these three packages (`jquery-aniview`, `jquery`, `animate.css`) are quite likely to be defined as dependencies of their common parent application (which is, most likely, a web site; could also be an application built on [Electron](http://electron.atom.io/), [NW.js](http://nwjs.io/), [JXcore for Cordova](https://github.com/jxcore/jxcore-cordova/), etc.) and thus to become peers in that sense. Currently, if some version mismatch happens on that level (under that parent), `npm` would install another version of `jquery` or `animate.css` under `jquery-aniview` (and that would be the versions required by `jquery-aniview` as its `dependencies`). However, because `jquery-aniview` does not rely on Node.js `require()`, that npm's behaviour does not really help anything, and thus `npm` should rather **warn** on version mismatch, like it does with `peerDependencies`.
- Likewise, if a user has some reason to refrain from `npm install jquery` (for example, that user might prefer to use a `<script src="…">` tag referencing [jQuery CDN](https://code.jquery.com/) instead of a local npm-installed jQuery), then `npm` should not decide to install jQuery as a dependency (which won't be used anyway); a warning about a missing peerDependency would be enough.
