### PR TITLE
Prefix 'animate__' for Animate.css V4 classes

### DIFF
--- a/dist/jquery.aniview.js
+++ b/dist/jquery.aniview.js
@@ -61,7 +61,7 @@
                 if ($(element).is('[data-av-animation]') && !$(elementParentContainer).hasClass('av-visible') && EnteringViewport(elementParentContainer)) {
                     $(element).css('opacity', 1);
                     $(elementParentContainer).addClass('av-visible');
-                    $(element).addClass('animated ' + $(element).attr('data-av-animation'));
+                    $(element).addClass('animate__animated animate__' + $(element).attr('data-av-animation'));
                 }
             });
         }


### PR DESCRIPTION
Hi, thanks for the package!

I tried for ages to get this working, and then realised it doesn't add on the new prefix to the classes that [Animate.css v4](https://animate.style/#migration) requires.

This now adds 'animate__' before the classes required - for example:

`<div id="animatethisdiv" class="animate__animated animate__fadeIn">Fade me in</div>`

Thanks, Chris